### PR TITLE
Add tea subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::SubscriptionsController < ApplicationController
+  def create
+    customer = Customer.find(params[:customer_id])
+    if customer
+      customer_subscription = customer.subscriptions.create!(subscription_params)
+      customer_tea_subscription = TeasSubscription.create!(subscription_id: customer_subscription.id, tea_id: params[:tea_id])
+      render json: {message: 'Sucessfully subscribed'}, status: 201
+    else
+      invalid_params
+    end
+  end
+
+  private
+    def subscription_params
+      params[:subscription][:status] = 0
+      params[:subscription].permit(:title, :price, :status, :frequency)
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
+  rescue_from ActiveRecord::RecordNotFound, with: :render_unprocessable_entity_response
+
+  def render_unprocessable_entity_response(exception)
+    render json: {error: exception.message}, status: 400
+  end
+
+  def invalid_params
+    render json: {error: 'invalid user'}, status: :bad_request
+  end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,7 +3,7 @@ class Subscription < ApplicationRecord
   has_many :teas_subscriptions
   has_many :teas, through: :teas_subscriptions
 
-  validates :title, :price, presence: true
+  validates :title, :price, :status, :frequency, presence: true
 
   enum status: [:active, :cancelled]
   enum frequency: [:weekly, :biweekly, :monthly]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :subscriptions, only: %i[create]
+    end
+  end
 end

--- a/spec/requests/api/v1/subscriptions/create_customer_tea_subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_customer_tea_subscription_request_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+RSpec.describe 'Customer Tea Subscription Request', type: :request do
+  describe 'happy path' do
+    it "subscribes a customer to a tea subscription" do
+      customer = create(:customer)
+      tea = create(:tea)
+      data = { customer_id: customer.id,
+               tea_id: tea.id,
+               subscription: { frequency: "monthly",
+               title: "Detox",
+               price: 12.99 }
+             }
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      post "/api/v1/subscriptions", headers: headers, params: JSON.generate(data)
+
+      subscription = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(subscription).to have_key(:message)
+      expect(subscription[:message]).to eq('Sucessfully subscribed')
+      expect(response.status).to eq(201)
+    end
+  end
+
+  describe "sad path" do
+    it "needs frequency attribute" do
+      customer = create(:customer)
+      tea = create(:tea)
+      data = { customer_id: customer.id,
+               tea_id: tea.id,
+               subscription: {
+               title: "Detox",
+               price: 12.99 }
+             }
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      post "/api/v1/subscriptions", headers: headers, params: JSON.generate(data)
+
+      subscription = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(subscription).to_not have_key(:message)
+      expect(subscription).to have_key(:error)
+      expect(subscription[:error]).to eq("Validation failed: Frequency can't be blank")
+      expect(response.status).to eq(400)
+    end
+
+    it "needs title attribute" do
+      customer = create(:customer)
+      tea = create(:tea)
+      data = { customer_id: customer.id,
+               tea_id: tea.id,
+               subscription: { frequency: "monthly",
+               price: 12.99 }
+             }
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      post "/api/v1/subscriptions", headers: headers, params: JSON.generate(data)
+
+      subscription = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(subscription).to_not have_key(:message)
+      expect(subscription).to have_key(:error)
+      expect(subscription[:error]).to eq("Validation failed: Title can't be blank")
+      expect(response.status).to eq(400)
+    end
+
+    it "needs price attribute" do
+      customer = create(:customer)
+      tea = create(:tea)
+      data = { customer_id: customer.id,
+               tea_id: tea.id,
+               subscription: { frequency: "monthly",
+               title: "Hello World" }
+             }
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      post "/api/v1/subscriptions", headers: headers, params: JSON.generate(data)
+
+      subscription = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(subscription).to_not have_key(:message)
+      expect(subscription).to have_key(:error)
+      expect(subscription[:error]).to eq("Validation failed: Price can't be blank")
+      expect(response.status).to eq(400)
+    end
+
+    it "needs customer id" do
+      tea = create(:tea)
+      data = { tea_id: tea.id,
+               subscription: {
+                 frequency: "monthly",
+                 price: 5.90,
+                 title: "Hello World" }
+             }
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      post "/api/v1/subscriptions", headers: headers, params: JSON.generate(data)
+
+      subscription = JSON.parse(response.body, symbolize_names: true)
+      expect(response).to_not be_successful
+      expect(subscription).to_not have_key(:message)
+      expect(subscription).to have_key(:error)
+      expect(subscription[:error]).to eq("Couldn't find Customer without an ID")
+      expect(response.status).to eq(400)
+    end
+
+    it "needs data" do
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+      post "/api/v1/subscriptions", headers: headers
+      subscription = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(subscription).to_not have_key(:message)
+      expect(subscription).to have_key(:error)
+      expect(subscription[:error]).to eq("Couldn't find Customer without an ID")
+      expect(response.status).to eq(400)
+    end
+  end
+end


### PR DESCRIPTION
This branch: 
* Adds functionality to post a customer tea subscription with sent in data in the requests body
* Added happy and sad path testing for required data fields in order to properly populate the record in database
* Modified `Subscription` validations for error handling.
* All tests are passing